### PR TITLE
Credential rotate function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Once awsx-cli is installed, you can start using it to manage your AWS credential
     ❯ awsx -r aws03
     Removed 'aws03' credentials successfully
     ```
+* To rotate credentials:
+ 
+     ```zsh
+    ❯ awsx -c foo -mfa 123456
+    Credentials rotated successfully
+    ```
 * To get help:
 
      ```zsh
@@ -119,6 +125,8 @@ Once awsx-cli is installed, you can start using it to manage your AWS credential
                             you can create creds from prompt
     -mfa UPDATE_MFA, --update-mfa UPDATE_MFA
                             update your mfa session
+    -c ROTATE_CREDENTIAL, --rotate-credential ROTATE_CREDENTIAL
+                          rotate your credentials (create new and remove previous) Example: awsx -c foo -mfa 123456
 
     ```
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name='awsx-cli',
-    version='1.0.4',
+    version='1.1.0',
     author='Mert Öngengil, Mehmet Eraslan',
     description='AWS credential management tool',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as readme_file:
 setup(
     name='awsx-cli',
     version='1.1.0',
-    author='Mert Öngengil, Mehmet Eraslan',
+    author='Mert Öngengil, Mehmet Eraslan, Engin Can Höke',
     description='AWS credential management tool',
     long_description=long_description,
     long_description_content_type="text/markdown", 


### PR DESCRIPTION
This function needs the user to have 1 credential, and if it does, the function gets the username with "iam get-user", then creates a second credential with "iam create-access-key" and overrides with the new key into the credential file under the config folder. Afterward, it deletes the old key from AWS by using "iam delete-access-key". 