### PR TITLE
Add MFA ARN support to awsx-cli and update README usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Once awsx-cli is installed, you can start using it to manage your AWS credential
     ❯ awsx -a aws04
     Stored 'aws04' credentials succesfully
     ```
+    or with the MFA ARN: 
+    ```zsh
+    ❯ awsx -a aws04 -m arn:aws:iam::123456789012:mfa/some-mfa-device
+    Stored 'aws04' credentials succesfully
+    ```
 
 * To both switch to a different set of credentials and update the MFA session:
 
@@ -109,25 +114,25 @@ Once awsx-cli is installed, you can start using it to manage your AWS credential
 
      ```zsh
     ❯ awsx --help
-    usage: awsx [-h] [-a ADD] [-r REMOVE] [-l] [-p ADD_PROMPT] [-mfa UPDATE_MFA]
-                [change]
+    usage: awsx [-h] [-a ADD] [-r REMOVE] [-l] [-p ADD_PROMPT] [-mfa UPDATE_MFA] [-c ROTATE_CREDENTIAL] [-m MFA_ARN] [change]
 
     positional arguments:
-    change                Example: awsx foo , awsx bar
+      change                Example: awsx foo , awsx bar
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -a ADD, --add ADD     add your credentials to awsx
-    -r REMOVE, --remove REMOVE
+      -h, --help            show this help message and exit
+      -a ADD, --add ADD     add your credentials to awsx
+      -r REMOVE, --remove REMOVE
                             remove your credentials from awsx
-    -l, --list            list your credentials from awsx
-    -p ADD_PROMPT, --add-prompt ADD_PROMPT
+      -l, --list            list your credentials from awsx
+      -p ADD_PROMPT, --add-prompt ADD_PROMPT
                             you can create creds from prompt
-    -mfa UPDATE_MFA, --update-mfa UPDATE_MFA
+      -mfa UPDATE_MFA, --update-mfa UPDATE_MFA
                             update your mfa session
-    -c ROTATE_CREDENTIAL, --rotate-credential ROTATE_CREDENTIAL
-                          rotate your credentials (create new and remove previous) Example: awsx -c foo -mfa 123456
-
+      -c ROTATE_CREDENTIAL, --rotate-credential ROTATE_CREDENTIAL
+                            rotate your credentials (create new and remove previous) Example: awsx -c foo -mfa 123456
+      -m MFA_ARN, --mfa-arn MFA_ARN
+                            add your MFA ARN along with the credentials to awsx
     ```
 
 

--- a/awsx.py
+++ b/awsx.py
@@ -113,7 +113,7 @@ def remove_selected_item(selected_creds):
         return "Cannot remove '{}' credentials".format(selected_creds)
     return "Removed '{}' credentials successfully".format(selected_creds)
 
-def store_item(creds_name):
+def store_item(creds_name, mfa_arn=None):
     stderr_1 = os.system(
         "mkdir -p {}/{}/".format(
             base_dir,
@@ -129,7 +129,10 @@ def store_item(creds_name):
         )
     if(stderr_1 != 0 or stderr_2 !=0):
         return "Cannot store '{}' credentials".format(creds_name)
-    return "Stored '{}' credentials succesfully".format(creds_name)
+    if mfa_arn:
+        with open("{}/{}/.mfa_arn".format(base_dir, creds_name), 'w') as mfa_file:
+            mfa_file.write(mfa_arn)
+    return "Stored '{}' credentials successfully".format(creds_name)
 
 def prompt_store_item(creds_name):
     stderr_1 = 0
@@ -167,7 +170,7 @@ def prompt_store_item(creds_name):
 
         if(stderr_1 != 0):
             return "Cannot store '{}' credentials".format(creds_name)
-        return "Stored '{}' credentials succesfully".format(creds_name)
+        return "Stored '{}' credentials successfully".format(creds_name)
     return "Cannot get values from prompt"
 
 def update_mfa(mfa_code):
@@ -285,6 +288,12 @@ def get_args():
         required = False,
         help = "rotate your credentials (create new and remove previous) Example: awsx -c foo -mfa 123456"
     )
+    parser.add_argument(
+        "-m",
+        "--mfa-arn",
+        required=False,
+        help="add your MFA ARN along with the credentials to awsx"
+    )
     return parser.parse_args()
 
 def parse_options(arguments):
@@ -293,7 +302,7 @@ def parse_options(arguments):
     elif(arguments.remove):
         return remove_selected_item(arguments.remove)
     elif(arguments.add):
-        return store_item(arguments.add)
+        return store_item(arguments.add, arguments.mfa_arn)
     elif(arguments.add_prompt):
         return prompt_store_item(arguments.add_prompt)
     elif(arguments.change):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name='awsx-cli',
-    version='1.1.1',
+    version='1.2.0',
     author='Mert Öngengil, Mehmet Eraslan, Engin Can Höke',
     description='AWS credential management tool',
     long_description=long_description,


### PR DESCRIPTION
An optional flag is added to "add" command to register MFA ARN to the ".mfa_arn" file. Usage example: "awsx -a some-name -m arn:aws:iam::123456789012:mfa/some-user"